### PR TITLE
fix(android): remove READ_MEDIA_IMAGES permission to use native Android Photo Picker

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ repositories {
 }
 
 dependencies {
-    implementation('io.intercom.android:intercom-sdk:15.1.4') {
+    implementation('io.intercom.android:intercom-sdk:15.1.5') {
         exclude group: 'com.google.code.gson', module: 'gson'
     }
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 5.0.2
+version: 6.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-intercom


### PR DESCRIPTION
Intercom SDK now uses native Android Photo Picker.

fix(android): updated Intercom SDK to `v15.1.5` to remove `READ_MEDIA_IMAGES` permission from generated manifest.