### PR TITLE
feat(android): update Intercom SDK to 15.16.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -3,7 +3,7 @@ repositories {
 }
 
 dependencies {
-    implementation('io.intercom.android:intercom-sdk:15.1.5') {
+    implementation('io.intercom.android:intercom-sdk:15.16.1') {
         exclude group: 'com.google.code.gson', module: 'gson'
     }
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 6.1.0
+version: 7.0.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-intercom
@@ -15,4 +15,4 @@ name: titanium-intercom
 moduleid: ti.intercom
 guid: a0354e09-4d47-4de7-8321-90d162393b55
 platform: android
-minsdk: 11.0.0
+minsdk: 12.7.0.GA


### PR DESCRIPTION
This PR attempts to resolve some ANRs that occurred when we moved the Intercom initialisation to the time of app creation in the last module version [6.1.0](https://github.com/hansemannn/titanium-intercom/releases/tag/android-6.1.0).

Note: This version requires the minimum Ti SDK 12.7.0.GA to support `compileSdkVersion: 34` and `Gradle 8.7+`.

Here's the compiled [module v7.0.0](https://github.com/user-attachments/files/20326983/ti.intercom-android-7.0.0.zip) tested with our app.

