### PR TITLE
fix(android): register for the later initialisation on Android 12 and 13

### DIFF
--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 7.0.0
+version: 7.0.1
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-intercom

--- a/android/src/ti/intercom/TitaniumIntercomModule.java
+++ b/android/src/ti/intercom/TitaniumIntercomModule.java
@@ -8,6 +8,8 @@
  */
 package ti.intercom;
 
+import android.os.Build;
+
 import androidx.annotation.NonNull;
 
 import org.appcelerator.kroll.KrollDict;
@@ -54,7 +56,13 @@ public class TitaniumIntercomModule extends KrollModule {
 		apiKey = app.getAppProperties().getString("intercom-android-api-key", null);
 		appId = app.getAppProperties().getString("intercom-app-id", null);
 
-		initialize();
+		// Defer the initialization on Android 12 and 13 to avoid ANRs as suggested by the Intercom Support team.
+		// It would further require that the Intercom.initialize() is called before any other Intercom API is used.
+		if (Build.VERSION.SDK_INT >= 31 && Build.VERSION.SDK_INT <= 33) {
+			Intercom.registerForLaterInitialisation(app);
+		} else {
+			initialize();
+		}
 	}
 
 	@Kroll.method
@@ -66,16 +74,19 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.setProperty
 	public void setVisible(boolean visible) {
+		initialize();
 		Intercom.client().setLauncherVisibility(visible ? Intercom.Visibility.VISIBLE : Intercom.Visibility.GONE);
 	}
 
 	@Kroll.setProperty
 	public void setBottomPadding(int bottomPadding) {
+		initialize();
 		Intercom.client().setBottomPadding(bottomPadding);
 	}
 
 	@Kroll.setProperty
 	public void setUserHash(String userHash) {
+		initialize();
 		if (userHash != null) {
 			Intercom.client().setUserHash(userHash);
 		}
@@ -83,6 +94,7 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
 	public void registerUser(@Kroll.argument(optional = true) KrollDict user) {
+		initialize();
 		if (user == null) {
 			Intercom.client().loginUnidentifiedUser(new IntercomStatusCallback() {
 				@Override
@@ -121,6 +133,7 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
     public void updateUser(KrollDict user) {
+		initialize();
 		String id = user.getString("id");
 		String email = user.getString("email");
 		String name = user.getString("name");
@@ -164,11 +177,13 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
 	public void logout() {
+		initialize();
 		Intercom.client().logout();
 	}
 
 	@Kroll.method
 	public void presentMessenger(@Kroll.argument(optional = true) String message) {
+		initialize();
 		if (message != null) {
 			Intercom.client().displayMessageComposer(message);
 		} else {
@@ -178,26 +193,31 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
 	public void presentSupportCenter() {
+		initialize();
 		Intercom.client().present();
 	}
 
 	@Kroll.method
 	public void presentMessageComposer(String message) {
+		initialize();
 		presentMessenger(message);
 	}
 
 	@Kroll.method
 	public void presentCarousel(String carouselId) {
+		initialize();
 		Intercom.client().presentContent(new IntercomContent.Carousel(carouselId));
 	}
 
 	@Kroll.method
 	public void presentHelpCenter() {
+		initialize();
 		Intercom.client().present(IntercomSpace.HelpCenter);
 	}
 
 	@Kroll.method
 	public void updatePushToken(String pushToken) {
+		initialize();
 		if (pushToken == null) {
 			pushToken = ""; // Reset token to empty string if deleted
 		}

--- a/android/src/ti/intercom/TitaniumIntercomModule.java
+++ b/android/src/ti/intercom/TitaniumIntercomModule.java
@@ -138,15 +138,15 @@ public class TitaniumIntercomModule extends KrollModule {
 		UserAttributes.Builder userAttributes = new UserAttributes.Builder();
 
 		if (id != null) {
-            userAttributes.withUserId(id);
+			userAttributes.withUserId(id);
         }
 
 		if (email != null) {
-            userAttributes.withEmail(email);
+			userAttributes.withEmail(email);
         }
 
 		if (name != null) {
-            userAttributes.withName(name);
+			userAttributes.withName(name);
         }
 
 		if (locale != null) {

--- a/android/src/ti/intercom/TitaniumIntercomModule.java
+++ b/android/src/ti/intercom/TitaniumIntercomModule.java
@@ -128,7 +128,7 @@ public class TitaniumIntercomModule extends KrollModule {
 	}
 
 	@Kroll.method
-    public void updateUser(KrollDict user) {
+	public void updateUser(KrollDict user) {
 		String id = user.getString("id");
 		String email = user.getString("email");
 		String name = user.getString("name");
@@ -139,15 +139,15 @@ public class TitaniumIntercomModule extends KrollModule {
 
 		if (id != null) {
 			userAttributes.withUserId(id);
-        }
+		}
 
 		if (email != null) {
 			userAttributes.withEmail(email);
-        }
+		}
 
 		if (name != null) {
 			userAttributes.withName(name);
-        }
+		}
 
 		if (locale != null) {
 			userAttributes.withLanguageOverride(locale);

--- a/android/src/ti/intercom/TitaniumIntercomModule.java
+++ b/android/src/ti/intercom/TitaniumIntercomModule.java
@@ -74,19 +74,16 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.setProperty
 	public void setVisible(boolean visible) {
-		initialize();
 		Intercom.client().setLauncherVisibility(visible ? Intercom.Visibility.VISIBLE : Intercom.Visibility.GONE);
 	}
 
 	@Kroll.setProperty
 	public void setBottomPadding(int bottomPadding) {
-		initialize();
 		Intercom.client().setBottomPadding(bottomPadding);
 	}
 
 	@Kroll.setProperty
 	public void setUserHash(String userHash) {
-		initialize();
 		if (userHash != null) {
 			Intercom.client().setUserHash(userHash);
 		}
@@ -94,7 +91,6 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
 	public void registerUser(@Kroll.argument(optional = true) KrollDict user) {
-		initialize();
 		if (user == null) {
 			Intercom.client().loginUnidentifiedUser(new IntercomStatusCallback() {
 				@Override
@@ -133,7 +129,6 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
     public void updateUser(KrollDict user) {
-		initialize();
 		String id = user.getString("id");
 		String email = user.getString("email");
 		String name = user.getString("name");
@@ -143,23 +138,23 @@ public class TitaniumIntercomModule extends KrollModule {
 		UserAttributes.Builder userAttributes = new UserAttributes.Builder();
 
 		if (id != null) {
-			userAttributes = userAttributes.withUserId(id);
-		}
+            userAttributes.withUserId(id);
+        }
 
 		if (email != null) {
-			userAttributes = userAttributes.withEmail(email);
-		}
+            userAttributes.withEmail(email);
+        }
 
 		if (name != null) {
-			userAttributes = userAttributes.withName(name);
-		}
+            userAttributes.withName(name);
+        }
 
 		if (locale != null) {
-			userAttributes = userAttributes.withLanguageOverride(locale);
+			userAttributes.withLanguageOverride(locale);
 		}
 
 		if (customAttributes != null) {
-			userAttributes = userAttributes.withCustomAttributes(customAttributes);
+			userAttributes.withCustomAttributes(customAttributes);
 		}
 
 		Intercom.client().updateUser(userAttributes.build(), new IntercomStatusCallback() {
@@ -177,13 +172,11 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
 	public void logout() {
-		initialize();
 		Intercom.client().logout();
 	}
 
 	@Kroll.method
 	public void presentMessenger(@Kroll.argument(optional = true) String message) {
-		initialize();
 		if (message != null) {
 			Intercom.client().displayMessageComposer(message);
 		} else {
@@ -193,31 +186,26 @@ public class TitaniumIntercomModule extends KrollModule {
 
 	@Kroll.method
 	public void presentSupportCenter() {
-		initialize();
 		Intercom.client().present();
 	}
 
 	@Kroll.method
 	public void presentMessageComposer(String message) {
-		initialize();
 		presentMessenger(message);
 	}
 
 	@Kroll.method
 	public void presentCarousel(String carouselId) {
-		initialize();
 		Intercom.client().presentContent(new IntercomContent.Carousel(carouselId));
 	}
 
 	@Kroll.method
 	public void presentHelpCenter() {
-		initialize();
 		Intercom.client().present(IntercomSpace.HelpCenter);
 	}
 
 	@Kroll.method
 	public void updatePushToken(String pushToken) {
-		initialize();
 		if (pushToken == null) {
 			pushToken = ""; // Reset token to empty string if deleted
 		}


### PR DESCRIPTION
This PR implements the following suggestions from the Intercom Support team to try preventing ANRs on Android 12 and 13.

- Use method `registerForLaterInitialisation()` in `onCreate`.
- Ensure that the `initialize()` must be called before accessing any other APIs.

